### PR TITLE
signals: before_record_index

### DIFF
--- a/invenio_records/signals.py
+++ b/invenio_records/signals.py
@@ -69,3 +69,21 @@ before_record_update = _signals.signal('before-record-update')
 
 after_record_update = _signals.signal('after-record-update')
 """Signal sent after a record is updated."""
+
+before_record_index = _signals.signal('before-record-index')
+"""Signal sent before a record is indexed.
+
+Example subscriber
+
+.. code-block:: python
+
+    def listener(sender, **kwargs):
+        info = fetch_some_info_for_recid(sender)
+        kwargs['json']['more_info'] = info
+
+    from invenio_records.signals import before_record_index
+
+    before_record_index.connect(
+        listener
+    )
+"""

--- a/invenio_records/tasks/index.py
+++ b/invenio_records/tasks/index.py
@@ -17,13 +17,17 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-import six
+"""Record indexing related Celery tasks."""
 
-from invenio.base.globals import cfg
+import six
 from invenio_celery import celery
 from invenio_ext.es import es
 from invenio_search.api import Query
 from invenio_search.walkers.elasticsearch import ElasticSearchDSL
+
+from invenio.base.globals import cfg
+
+from ..signals import before_record_index
 
 
 def get_record_index(record):
@@ -39,6 +43,7 @@ def get_record_index(record):
 @celery.task
 def index_record(recid, json):
     """Index a record in elasticsearch."""
+    before_record_index.send(recid, json=json)
     index = get_record_index(json) or cfg['SEARCH_ELASTIC_DEFAULT_INDEX']
     es.index(
         index=index,


### PR DESCRIPTION
- NEW Introduces new signal before_record_index, which is triggered
  in index_record() task, in order to enhance on the fly the JSON
  being set to Elasticsearch.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
