### PR TITLE
record: save deep copy of initial json

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -64,8 +64,11 @@ class Record(SmartDict):
         return super(Record, self).__setitem__(key, value)
 
     def __init__(self, data, model=None):
+        import copy
         self.model = model
+        self.init_json = copy.deepcopy(data)
         super(Record, self).__init__(data)
+
 
     @classmethod
     def create(cls, data, schema=None):


### PR DESCRIPTION
- deep copy can be used after update to compare new version of the record with the old one

Signed-off-by: Tomasz tomaszgy@gmail.com
